### PR TITLE
Adding dependency for beautifulsoup4

### DIFF
--- a/custom_components/alarmdotcomajax/manifest.json
+++ b/custom_components/alarmdotcomajax/manifest.json
@@ -2,7 +2,10 @@
   "domain": "alarmdotcomajax",
   "name": "Alarm.com",
   "documentation": "https://www.github.com/uvjustin/alarmdotcomajax",
-  "requirements": ["pyalarmdotcomajax==0.1.2"],
+  "requirements": [
+    "beautifulsoup4==4.9.0",
+    "pyalarmdotcomajax==0.1.2"
+  ],
   "dependencies": [],
   "codeowners": ["@uvjustin"]
 }

--- a/custom_components/alarmdotcomajax/manifest.json
+++ b/custom_components/alarmdotcomajax/manifest.json
@@ -3,7 +3,7 @@
   "name": "Alarm.com",
   "documentation": "https://www.github.com/uvjustin/alarmdotcomajax",
   "requirements": [
-    "beautifulsoup4==4.9.0",
+    "beautifulsoup4",
     "pyalarmdotcomajax==0.1.2"
   ],
   "dependencies": [],


### PR DESCRIPTION
Adding dependency for beautifulsoup4, since the install of pyalarmdotcomajax==0.1.2 would fail ("ModuleNotFoundError: No module named 'bs4'") when running the Home Assistant config check command ("hass --script check_config -i -f") on a clean install.

If there's a better way of implementing this then please let me know!